### PR TITLE
feat(roles): 역할 시스템 정비(UserRole enum, HasRoles 연동, 문서 추가)

### DIFF
--- a/.github/workflows/phase2-quality.yml
+++ b/.github/workflows/phase2-quality.yml
@@ -59,6 +59,34 @@ jobs:
           cp .env.example .env
           php artisan key:generate
 
+      - name: Create Vite manifest for tests
+        run: |
+          mkdir -p public/build
+          cat > public/build/manifest.json << 'EOF'
+          {
+            "resources/css/app.css": {
+              "file": "assets/app.css",
+              "src": "resources/css/app.css"
+            },
+            "resources/css/customer-app.css": {
+              "file": "assets/customer-app.css",
+              "src": "resources/css/customer-app.css"
+            },
+            "resources/js/app.js": {
+              "file": "assets/app.js",
+              "src": "resources/js/app.js"
+            },
+            "resources/js/auth-login.js": {
+              "file": "assets/auth-login.js",
+              "src": "resources/js/auth-login.js"
+            },
+            "resources/js/customer-app.tsx": {
+              "file": "assets/customer-app.js",
+              "src": "resources/js/customer-app.tsx"
+            }
+          }
+          EOF
+
       - name: Run Laravel Pint (Code Style)
         run: vendor/bin/pint --test
 

--- a/app/Enums/UserRole.php
+++ b/app/Enums/UserRole.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+/**
+ * System role names in a single source of truth.
+ */
+enum UserRole: string
+{
+    case ADMIN = 'admin';
+    case ORG_ADMIN = 'org_admin';
+    case STORE_OWNER = 'store_owner';
+    case STORE_MANAGER = 'store_manager';
+    case STAFF = 'staff';
+    case CUSTOMER = 'customer';
+
+    /**
+     * @return list<string>
+     */
+    public static function toArray(): array
+    {
+        return array_map(static fn (self $r): string => $r->value, self::cases());
+    }
+
+    /**
+     * Roles allowed to access Filament panel.
+     *
+     * @return list<string>
+     */
+    public static function panelAccess(): array
+    {
+        return [
+            self::ADMIN->value,
+            self::ORG_ADMIN->value,
+            self::STORE_OWNER->value,
+            self::STORE_MANAGER->value,
+            self::STAFF->value,
+        ];
+    }
+}

--- a/app/Http/Controllers/Customer/AuthController.php
+++ b/app/Http/Controllers/Customer/AuthController.php
@@ -17,6 +17,7 @@ use Inertia\Response;
 use Kreait\Firebase\Contract\Auth as FirebaseAuth;
 use Kreait\Firebase\Exception\Auth\FailedToVerifyToken;
 use Kreait\Firebase\Factory;
+use App\Enums\UserRole;
 
 /**
  * 고객 인증 컨트롤러
@@ -92,6 +93,11 @@ class AuthController extends Controller
 
             // 7. 마지막 로그인 시간 업데이트
             $user->updateLastLoginAt();
+
+            // 7-1. 기본 고객 역할 부여 (없을 경우)
+            if (! $user->hasRole(UserRole::CUSTOMER->value)) {
+                $user->assignRole(UserRole::CUSTOMER->value);
+            }
 
             // 8. 성공 응답
             return response()->json([

--- a/app/Http/Controllers/Customer/AuthController.php
+++ b/app/Http/Controllers/Customer/AuthController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\Customer;
 
+use App\Enums\UserRole;
 use App\Http\Controllers\Controller;
 use App\Models\User;
 use Illuminate\Http\JsonResponse;
@@ -17,7 +18,6 @@ use Inertia\Response;
 use Kreait\Firebase\Contract\Auth as FirebaseAuth;
 use Kreait\Firebase\Exception\Auth\FailedToVerifyToken;
 use Kreait\Firebase\Factory;
-use App\Enums\UserRole;
 
 /**
  * 고객 인증 컨트롤러

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -5,18 +5,18 @@ declare(strict_types=1);
 namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
+use App\Enums\UserRole;
 use Filament\Models\Contracts\FilamentUser;
 use Filament\Panel;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Spatie\Permission\Traits\HasRoles;
-use App\Enums\UserRole;
 
 class User extends Authenticatable implements FilamentUser
 {
     /** @use HasFactory<\Database\Factories\UserFactory> */
-    use HasFactory, Notifiable, HasRoles;
+    use HasFactory, HasRoles, Notifiable;
 
     /**
      * The attributes that are mass assignable.

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -10,11 +10,13 @@ use Filament\Panel;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Spatie\Permission\Traits\HasRoles;
+use App\Enums\UserRole;
 
 class User extends Authenticatable implements FilamentUser
 {
     /** @use HasFactory<\Database\Factories\UserFactory> */
-    use HasFactory, Notifiable;
+    use HasFactory, Notifiable, HasRoles;
 
     /**
      * The attributes that are mass assignable.
@@ -114,10 +116,8 @@ class User extends Authenticatable implements FilamentUser
      */
     public function canAccessPanel(Panel $panel): bool
     {
-        // 현재는 모든 인증된 사용자가 접근 가능
-        // 향후 역할 기반 접근 제어(RBAC) 구현 시 수정 필요
-        // 예: return $this->hasRole('admin') || $this->hasRole('store_manager');
-        return true;
+        // Allow only staff+ roles to access Filament
+        return $this->hasRole(UserRole::panelAccess());
     }
 
     /**

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -5,6 +5,8 @@ namespace Database\Seeders;
 use App\Models\User;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
+use Spatie\Permission\Models\Role;
+use App\Enums\UserRole;
 
 class DatabaseSeeder extends Seeder
 {
@@ -13,11 +15,24 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // User::factory(10)->create();
+        // 1) Create default roles from enum
+        foreach (UserRole::toArray() as $roleName) {
+            Role::findOrCreate($roleName);
+        }
 
-        User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
-        ]);
+        // 2) Create a sample admin user only in local environment
+        if (app()->environment('local')) {
+            $user = User::firstOrCreate(
+                ['email' => 'test@example.com'],
+                [
+                    'name' => 'Test User',
+                    // Local-only default password
+                    'password' => bcrypt('password'),
+                ]
+            );
+
+            // 3) Assign admin role to the sample user
+            $user->syncRoles([UserRole::ADMIN->value]);
+        }
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,11 +2,11 @@
 
 namespace Database\Seeders;
 
-use App\Models\User;
+use App\Enums\UserRole;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use App\Models\User;
 use Illuminate\Database\Seeder;
 use Spatie\Permission\Models\Role;
-use App\Enums\UserRole;
 
 class DatabaseSeeder extends Seeder
 {

--- a/docs/organizations.md
+++ b/docs/organizations.md
@@ -1,0 +1,32 @@
+# Organizations 설계 (최소 단위)
+
+Organizations는 회사(법인) 단위의 상위 엔터티입니다. Stores는 조직에 속할 수도 있고, 독립적으로 운영될 수도 있습니다.
+
+## 스키마 (초안)
+- id (PK)
+- name: string(255)
+- slug: string(255, unique)
+- is_active: boolean (default: true)
+- contact_email: string(255, nullable)
+- contact_phone: string(50, nullable)
+- settings: json (nullable)
+- timestamps
+
+## 모델
+- 파일: `app/Models/Organization.php`
+- fillable: name, slug, is_active, contact_email, contact_phone, settings
+- casts: is_active(bool), settings(array)
+
+## 관리(Management)
+- 우선 Filament로 CRUD 제공 (Public API는 보류)
+- 접근 제어는 추후 `OrganizationPolicy` 및 Role 기반으로 강화
+
+## 확장 포인트
+- Stores와의 관계: `stores.organization_id` (nullable)
+- 조직 관리자(organization_managers) 피벗 (차기 단계)
+- 회계/세금/영업시간 등 설정의 JSON 스키마 구체화
+
+## 우선순위 작업
+1) 마이그레이션/모델 작성
+2) Filament Resource 생성 (List/Create/Edit)
+3) 기본 검증 및 unique(slug) 보장

--- a/docs/pr/roles-pr-body.ko.md
+++ b/docs/pr/roles-pr-body.ko.md
@@ -1,0 +1,35 @@
+# 변경 사항
+
+- **[역할 시스템 연동]**
+  - `app/Models/User.php`: Spatie `HasRoles` 트레이트 적용
+  - Filament 접근 제한: `UserRole::panelAccess()` 보유 롤만 접근 가능
+- **[Enum 도입]**
+  - `app/Enums/UserRole.php`: 시스템 역할 단일 출처
+  - `toArray()`, `panelAccess()` 제공
+- **[시더 정비]**
+  - `database/seeders/DatabaseSeeder.php`
+    - 기본 롤은 `UserRole::toArray()`로 생성
+    - 샘플 관리자 유저는 `local` 환경에서만 생성 및 `ADMIN` 롤 부여
+- **[인증 플로우 보완]**
+  - `app/Http/Controllers/Customer/AuthController.php`: Firebase 로그인 성공 시 `CUSTOMER` 롤 자동 부여(미보유 시)
+- **[문서 추가]**
+  - `docs/roles-and-permissions.md`
+  - `docs/organizations.md`
+
+# 마이그레이션/시드
+- Spatie permission 테이블 필요 시 `php artisan migrate`
+- 로컬 개발에서 기본 롤/샘플 유저 확인: `php artisan db:seed`
+- 운영 환경에서는 샘플 유저는 생성되지 않음(별도 CLI로 생성 필요)
+
+# 영향 범위
+- 관리자 패널 접근 권한이 롤 기반으로 제한됨(`customer`는 접근 불가)
+- 로그인 시 고객 역할 자동 부여로 고객 영역 권한 판별이 명확해짐
+
+# 후속 작업(별도 PR)
+- `OrganizationPolicy` 및 Filament Resource 권한 연동
+- Stores/Managers/Invitations 도입 시 역할/정책 세분화
+- Public API(organizations)는 소비자 정의 후 설계
+
+# 테스트 방법
+- 로컬에서 마이그레이션 및 시드 실행 후, Filament 접근 권한 확인
+- Firebase 로그인 → 세션 확립 후 사용자에 `customer` 롤 부여 확인

--- a/docs/roles-and-permissions.md
+++ b/docs/roles-and-permissions.md
@@ -1,0 +1,28 @@
+# Roles and Permissions
+
+본 문서는 롤/권한 체계의 최소 설계를 설명합니다. 코드와 주석은 영어, 문서는 한국어로 작성합니다.
+
+## 롤 분류 (Taxonomy)
+- admin
+- org_admin
+- store_owner
+- store_manager
+- staff
+- customer
+
+고객앱 이용자는 기본적으로 `customer` 롤을 부여받습니다. 관리자 패널(Filament)은 `admin | org_admin | store_owner | store_manager | staff`만 접근 가능합니다.
+
+## 시스템 연동
+- User 모델: `Spatie\Permission\Traits\HasRoles` 적용
+- 시더: `DatabaseSeeder`에서 기본 롤 생성 및 샘플 유저에 롤 할당
+- 로그인 플로우: Firebase 로그인 성공 시 `customer` 롤 자동 부여 (미보유 시)
+
+## 접근 제어 원칙
+- 관리자 패널(Filament): 운영/관리 롤만 접근 (customer 제외)
+- 고객 API/화면: web 세션 인증 + customer 롤 보유 여부 기반(필요 시)
+- 정책(Policies): 차기 단계에서 Organization/Store 단위 권한 세분화
+
+## 추후 확장
+- 조직/매장 단위 권한(organization_managers, store_managers) 도입
+- 권한(Permissions) 세분화 후 롤에 매핑
+- 활동 로그 및 감사지원

--- a/tests/Feature/FirebaseAuthTest.php
+++ b/tests/Feature/FirebaseAuthTest.php
@@ -12,9 +12,9 @@ use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Session;
 use Kreait\Firebase\Exception\Auth\FailedToVerifyToken;
 use Mockery;
-use Tests\TestCase;
-use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
 
 /**
  * Firebase 인증 기능 테스트
@@ -29,7 +29,6 @@ use PHPUnit\Framework\Attributes\Group;
  * - 언어 변경
  * - API 엔드포인트 인증
  * - 보호된 라우트 접근 제어
- *
  */
 #[Group('firebase')]
 class FirebaseAuthTest extends TestCase
@@ -998,8 +997,8 @@ class FirebaseAuthTest extends TestCase
     }
 
     /**
-      * 테스트: 다른 디바이스에서 로그인 시 세션 동시 유지 (다중 세션)
-      */
+     * 테스트: 다른 디바이스에서 로그인 시 세션 동시 유지 (다중 세션)
+     */
     public function test_allows_multiple_sessions_from_different_devices(): void
     {
         // Arrange: 사용자 토큰 데이터

--- a/tests/Feature/FirebaseServiceIntegrationTest.php
+++ b/tests/Feature/FirebaseServiceIntegrationTest.php
@@ -8,9 +8,9 @@ use App\Models\User;
 use App\Services\FirebaseService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Config;
-use Tests\TestCase;
-use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use Tests\TestCase;
 
 /**
  * FirebaseService 통합 테스트

--- a/tests/Unit/FirebaseServiceTest.php
+++ b/tests/Unit/FirebaseServiceTest.php
@@ -87,5 +87,4 @@ class FirebaseServiceTest extends TestCase
             $this->assertEquals($expectedName, $actualName);
         }
     }
-
 }


### PR DESCRIPTION
# 변경 사항

- **[역할 시스템 연동]**
  - `app/Models/User.php`: Spatie `HasRoles` 트레이트 적용
  - Filament 접근 제한: `UserRole::panelAccess()` 보유 롤만 접근 가능
- **[Enum 도입]**
  - `app/Enums/UserRole.php`: 시스템 역할 단일 출처
  - `toArray()`, `panelAccess()` 제공
- **[시더 정비]**
  - `database/seeders/DatabaseSeeder.php`
    - 기본 롤은 `UserRole::toArray()`로 생성
    - 샘플 관리자 유저는 `local` 환경에서만 생성 및 `ADMIN` 롤 부여
- **[인증 플로우 보완]**
  - `app/Http/Controllers/Customer/AuthController.php`: Firebase 로그인 성공 시 `CUSTOMER` 롤 자동 부여(미보유 시)
- **[문서 추가]**
  - `docs/roles-and-permissions.md`
  - `docs/organizations.md`

# 마이그레이션/시드
- Spatie permission 테이블 필요 시 `php artisan migrate`
- 로컬 개발에서 기본 롤/샘플 유저 확인: `php artisan db:seed`
- 운영 환경에서는 샘플 유저는 생성되지 않음(별도 CLI로 생성 필요)

# 영향 범위
- 관리자 패널 접근 권한이 롤 기반으로 제한됨(`customer`는 접근 불가)
- 로그인 시 고객 역할 자동 부여로 고객 영역 권한 판별이 명확해짐

# 후속 작업(별도 PR)
- `OrganizationPolicy` 및 Filament Resource 권한 연동
- Stores/Managers/Invitations 도입 시 역할/정책 세분화
- Public API(organizations)는 소비자 정의 후 설계

# 테스트 방법
- 로컬에서 마이그레이션 및 시드 실행 후, Filament 접근 권한 확인
- Firebase 로그인 → 세션 확립 후 사용자에 `customer` 롤 부여 확인
