### PR TITLE
[Config] Spatie Permission Teams 활성화 및 세션 기반 스코프 컨텍스트 관리

### DIFF
--- a/app/Permissions/CurrentScopeResolver.php
+++ b/app/Permissions/CurrentScopeResolver.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Permissions;
+
+use App\Services\ScopeContextService;
+
+/**
+ * CurrentScopeResolver
+ * 
+ * Spatie Permission Teams 기능을 위한 커스텀 team_resolver.
+ * ScopeContextService를 통해 세션 기반 스코프 컨텍스트를 조회하여 team_id 반환.
+ * 
+ * 동작 방식:
+ * 1. ScopeContextService에서 현재 활성 스코프 조회 (세션 기반)
+ * 2. scopes 테이블에서 해당 스코프의 team_id(scopes.id) 반환
+ * 3. 컨텍스트가 없으면 null 반환 (글로벌 권한)
+ * 
+ * @see config/permission.php 'team_resolver'
+ * @see \App\Services\ScopeContextService
+ */
+class CurrentScopeResolver
+{
+    /**
+     * @var ScopeContextService
+     */
+    private ScopeContextService $scopeContext;
+
+    public function __construct(ScopeContextService $scopeContext)
+    {
+        $this->scopeContext = $scopeContext;
+    }
+
+    /**
+     * Spatie Permission이 호출하는 메서드.
+     * 현재 요청의 활성 스코프(team_id)를 반환.
+     * 
+     * @return int|null scopes.id 또는 null(글로벌 컨텍스트)
+     */
+    public function __invoke(): ?int
+    {
+        return $this->scopeContext->getCurrentTeamId();
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -11,7 +11,8 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        //
+        // ScopeContextService를 싱글톤으로 등록
+        $this->app->singleton(\App\Services\ScopeContextService::class);
     }
 
     /**

--- a/app/Services/ScopeContextService.php
+++ b/app/Services/ScopeContextService.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Session;
+
+/**
+ * ScopeContextService
+ * 
+ * 현재 사용자의 활성 스코프 컨텍스트를 일원화하여 관리하는 서비스.
+ * 세션 기반으로 스코프 정보를 저장/조회/검증.
+ * 
+ * 사용처:
+ * - CurrentScopeResolver: team_id 반환
+ * - SetScopeContext 미들웨어: 컨텍스트 검증
+ * - Filament UI: 스코프 스위처
+ * - 컨트롤러/서비스: 현재 스코프 조회
+ */
+class ScopeContextService
+{
+    /**
+     * 세션 키 상수
+     */
+    private const SESSION_SCOPE_TYPE = 'current_scope_type';
+    private const SESSION_SCOPE_ID = 'current_scope_id';
+    private const SESSION_SCOPE_TEAM_ID = 'current_scope_team_id'; // 캐시용
+
+    /**
+     * 현재 활성 스코프 타입 반환
+     * 
+     * @return string|null 'ORG'|'BRAND'|'STORE'|null
+     */
+    public function getCurrentScopeType(): ?string
+    {
+        return Session::get(self::SESSION_SCOPE_TYPE);
+    }
+
+    /**
+     * 현재 활성 스코프 ID 반환 (실제 엔터티 PK)
+     * 
+     * @return int|null
+     */
+    public function getCurrentScopeId(): ?int
+    {
+        return Session::get(self::SESSION_SCOPE_ID);
+    }
+
+    /**
+     * 현재 활성 스코프의 team_id 반환 (scopes.id)
+     * 캐시된 값이 있으면 반환, 없으면 DB 조회 후 캐시.
+     * 
+     * @return int|null
+     */
+    public function getCurrentTeamId(): ?int
+    {
+        $scopeType = $this->getCurrentScopeType();
+        $scopeId = $this->getCurrentScopeId();
+
+        if (!$scopeType || !$scopeId) {
+            return null;
+        }
+
+        // 세션에 캐시된 team_id가 있으면 반환
+        $cachedTeamId = Session::get(self::SESSION_SCOPE_TEAM_ID);
+        if ($cachedTeamId) {
+            return $cachedTeamId;
+        }
+
+        // TODO: scopes 테이블 조회 (마이그레이션 완료 후 활성화)
+        // $scope = \App\Models\Scope::where('scope_type', $scopeType)
+        //     ->where('scope_ref_id', $scopeId)
+        //     ->first();
+        // 
+        // if ($scope) {
+        //     // 세션에 캐시
+        //     Session::put(self::SESSION_SCOPE_TEAM_ID, $scope->id);
+        //     return $scope->id;
+        // }
+
+        return null;
+    }
+
+    /**
+     * 스코프 컨텍스트 설정
+     * 
+     * @param string $scopeType 'ORG'|'BRAND'|'STORE'
+     * @param int $scopeId 실제 엔터티 PK
+     * @param int|null $teamId scopes.id (선택, 없으면 자동 조회)
+     * @return void
+     */
+    public function setScope(string $scopeType, int $scopeId, ?int $teamId = null): void
+    {
+        Session::put([
+            self::SESSION_SCOPE_TYPE => $scopeType,
+            self::SESSION_SCOPE_ID => $scopeId,
+        ]);
+
+        // team_id가 제공되면 캐시
+        if ($teamId !== null) {
+            Session::put(self::SESSION_SCOPE_TEAM_ID, $teamId);
+        } else {
+            // team_id 캐시 무효화 (다음 조회 시 재계산)
+            Session::forget(self::SESSION_SCOPE_TEAM_ID);
+        }
+    }
+
+    /**
+     * 스코프 컨텍스트 초기화 (로그아웃 또는 권한 상실 시)
+     * 
+     * @return void
+     */
+    public function clearScope(): void
+    {
+        Session::forget([
+            self::SESSION_SCOPE_TYPE,
+            self::SESSION_SCOPE_ID,
+            self::SESSION_SCOPE_TEAM_ID,
+        ]);
+    }
+
+    /**
+     * 현재 컨텍스트가 설정되어 있는지 확인
+     * 
+     * @return bool
+     */
+    public function hasScope(): bool
+    {
+        return $this->getCurrentScopeType() !== null 
+            && $this->getCurrentScopeId() !== null;
+    }
+
+    /**
+     * 현재 컨텍스트 정보를 배열로 반환
+     * 
+     * @return array{type: string|null, id: int|null, team_id: int|null}
+     */
+    public function getCurrentScope(): array
+    {
+        return [
+            'type' => $this->getCurrentScopeType(),
+            'id' => $this->getCurrentScopeId(),
+            'team_id' => $this->getCurrentTeamId(),
+        ];
+    }
+
+    /**
+     * 사용자가 특정 스코프에 접근 권한이 있는지 검증
+     * 
+     * @param \App\Models\User $user
+     * @param string $scopeType
+     * @param int $scopeId
+     * @return bool
+     */
+    public function userCanAccessScope($user, string $scopeType, int $scopeId): bool
+    {
+        // TODO: Membership 모델 구현 후 활성화
+        // return $user->memberships()
+        //     ->where('scope_type', $scopeType)
+        //     ->where('scope_ref_id', $scopeId)
+        //     ->exists();
+
+        // 임시: 모든 접근 허용 (개발 단계)
+        return true;
+    }
+
+    /**
+     * 사용자의 첫 번째 멤버십을 기본 컨텍스트로 설정
+     * 
+     * @param \App\Models\User $user
+     * @return bool 설정 성공 여부
+     */
+    public function setDefaultScopeForUser($user): bool
+    {
+        // TODO: Membership 모델 구현 후 활성화
+        // $firstMembership = $user->memberships()->first();
+        // 
+        // if ($firstMembership) {
+        //     $this->setScope(
+        //         $firstMembership->scope_type,
+        //         $firstMembership->scope_ref_id
+        //     );
+        //     return true;
+        // }
+
+        return false;
+    }
+}

--- a/app/Services/ScopeContextService.php
+++ b/app/Services/ScopeContextService.php
@@ -151,7 +151,7 @@ class ScopeContextService
      * @param int $scopeId
      * @return bool
      */
-    public function userCanAccessScope($user, string $scopeType, int $scopeId): bool
+    public function userCanAccessScope(\App\Models\User $user, string $scopeType, int $scopeId): bool
     {
         // TODO: Membership 모델 구현 후 활성화
         // return $user->memberships()
@@ -169,7 +169,7 @@ class ScopeContextService
      * @param \App\Models\User $user
      * @return bool 설정 성공 여부
      */
-    public function setDefaultScopeForUser($user): bool
+    public function setDefaultScopeForUser(\App\Models\User $user): bool
     {
         // TODO: Membership 모델 구현 후 활성화
         // $firstMembership = $user->memberships()->first();

--- a/app/Support/helpers.php
+++ b/app/Support/helpers.php
@@ -16,3 +16,27 @@ if (! function_exists('csp_nonce')) {
         return $request->attributes->get('csp-nonce', '') ?? '';
     }
 }
+
+if (!function_exists('scopeContext')) {
+    /**
+     * 스코프 컨텍스트 서비스 인스턴스 반환
+     * 
+     * @return \App\Services\ScopeContextService
+     */
+    function scopeContext(): \App\Services\ScopeContextService
+    {
+        return app(\App\Services\ScopeContextService::class);
+    }
+}
+
+if (!function_exists('currentScopeTeamId')) {
+    /**
+     * 현재 활성 스코프의 team_id 반환 (Spatie Permission용)
+     * 
+     * @return int|null
+     */
+    function currentScopeTeamId(): ?int
+    {
+        return scopeContext()->getCurrentTeamId();
+    }
+}

--- a/config/permission.php
+++ b/config/permission.php
@@ -131,12 +131,12 @@ return [
      * (view the latest version of this package's migration file)
      */
 
-    'teams' => false,
+    'teams' => true,
 
     /*
      * The class to use to resolve the permissions team id
      */
-    'team_resolver' => \Spatie\Permission\DefaultTeamResolver::class,
+    'team_resolver' => \App\Permissions\CurrentScopeResolver::class,
 
     /*
      * Passport Client Credentials Grant
@@ -151,7 +151,7 @@ return [
      * setting is false here for optimum safety.
      */
 
-    'display_permission_in_exception' => false,
+    'display_permission_in_exception' => true,
 
     /*
      * When set to true, the required role names are added to exception messages.
@@ -159,7 +159,7 @@ return [
      * setting is false here for optimum safety.
      */
 
-    'display_role_in_exception' => false,
+    'display_role_in_exception' => true,
 
     /*
      * By default wildcard permission lookups are disabled.

--- a/docs/scope-context-usage.md
+++ b/docs/scope-context-usage.md
@@ -1,0 +1,241 @@
+# 스코프 컨텍스트 사용 가이드
+
+## 개요
+
+`ScopeContextService`는 세션 기반으로 현재 사용자의 활성 스코프(Organization/Brand/Store)를 일원화하여 관리합니다.
+
+## 아키텍처
+
+```
+사용자 로그인
+    ↓
+스코프 선택 (UI 스위처 또는 자동)
+    ↓
+ScopeContextService::setScope()
+    ↓
+세션 저장 (scope_type, scope_id, team_id)
+    ↓
+CurrentScopeResolver (Spatie Permission)
+    ↓
+권한 체크 (hasRole/can)
+```
+
+## 기본 사용법
+
+### 1. 헬퍼 함수 사용 (권장)
+
+```php
+// 서비스 인스턴스 가져오기
+$service = scopeContext();
+
+// 현재 스코프 정보 조회
+$scopeType = scopeContext()->getCurrentScopeType(); // 'ORG'|'BRAND'|'STORE'|null
+$scopeId = scopeContext()->getCurrentScopeId();     // 실제 엔터티 PK
+$teamId = scopeContext()->getCurrentTeamId();       // scopes.id (Spatie team_id)
+
+// 또는 한 번에
+$scope = scopeContext()->getCurrentScope();
+// ['type' => 'STORE', 'id' => 123, 'team_id' => 456]
+
+// 컨텍스트 존재 여부 확인
+if (scopeContext()->hasScope()) {
+    // 스코프가 설정되어 있음
+}
+
+// Spatie Permission용 team_id만 필요한 경우
+$teamId = currentScopeTeamId();
+```
+
+### 2. 의존성 주입 사용
+
+```php
+use App\Services\ScopeContextService;
+
+class StoreController extends Controller
+{
+    public function __construct(
+        private ScopeContextService $scopeContext
+    ) {}
+
+    public function index()
+    {
+        $currentScope = $this->scopeContext->getCurrentScope();
+        
+        // 현재 스코프 내의 데이터만 조회
+        $stores = Store::where('id', $currentScope['id'])->get();
+    }
+}
+```
+
+## 주요 시나리오
+
+### 시나리오 1: 스코프 설정 (UI 스위처)
+
+```php
+// Filament 컴포넌트 또는 컨트롤러
+public function switchScope(Request $request)
+{
+    $scopeType = $request->input('scope_type'); // 'STORE'
+    $scopeId = $request->input('scope_id');     // 123
+    
+    // 권한 검증
+    if (!scopeContext()->userCanAccessScope(auth()->user(), $scopeType, $scopeId)) {
+        abort(403, '해당 스코프에 접근 권한이 없습니다.');
+    }
+    
+    // 스코프 설정
+    scopeContext()->setScope($scopeType, $scopeId);
+    
+    return redirect()->back();
+}
+```
+
+### 시나리오 2: 로그인 후 기본 스코프 설정
+
+```php
+// LoginController 또는 미들웨어
+public function authenticated(Request $request, $user)
+{
+    // 사용자의 첫 번째 멤버십을 기본 스코프로 설정
+    if (!scopeContext()->hasScope()) {
+        scopeContext()->setDefaultScopeForUser($user);
+    }
+}
+```
+
+### 시나리오 3: 미들웨어에서 컨텍스트 검증
+
+```php
+// SetScopeContext 미들웨어
+public function handle($request, Closure $next)
+{
+    if (!scopeContext()->hasScope()) {
+        // 스코프 미설정 시 선택 화면으로
+        return redirect()->route('scope.select');
+    }
+    
+    $scope = scopeContext()->getCurrentScope();
+    
+    // 사용자 권한 재검증
+    if (!scopeContext()->userCanAccessScope(auth()->user(), $scope['type'], $scope['id'])) {
+        // 권한 상실 시 컨텍스트 초기화
+        scopeContext()->clearScope();
+        return redirect()->route('scope.select')
+            ->with('error', '해당 스코프에 대한 접근 권한이 없습니다.');
+    }
+    
+    return $next($request);
+}
+```
+
+### 시나리오 4: 로그아웃 시 컨텍스트 초기화
+
+```php
+// LogoutController
+public function logout(Request $request)
+{
+    scopeContext()->clearScope();
+    
+    Auth::logout();
+    $request->session()->invalidate();
+    $request->session()->regenerateToken();
+    
+    return redirect('/');
+}
+```
+
+### 시나리오 5: Spatie Permission과 통합
+
+```php
+// 컨트롤러 또는 정책
+public function store(Request $request)
+{
+    // 현재 스코프 컨텍스트에서 권한 체크
+    // Spatie가 자동으로 CurrentScopeResolver를 통해 team_id를 가져감
+    
+    if (!auth()->user()->can('stores.create')) {
+        abort(403);
+    }
+    
+    // 현재 스코프 내에서만 생성
+    $store = Store::create([
+        'scope_type' => scopeContext()->getCurrentScopeType(),
+        'scope_id' => scopeContext()->getCurrentScopeId(),
+        // ...
+    ]);
+}
+```
+
+## 세션 키 구조
+
+```php
+// 세션에 저장되는 키
+'current_scope_type'    => 'STORE'  // 스코프 타입
+'current_scope_id'      => 123      // 실제 엔터티 PK
+'current_scope_team_id' => 456      // scopes.id (캐시)
+```
+
+## 주의사항
+
+### 1. 세션 기반이므로 서버 사이드 렌더링에 적합
+- Filament와 같은 전통적인 Laravel 앱에 최적화
+- API 전용 앱은 토큰 기반 컨텍스트 전달 고려 필요
+
+### 2. team_id 캐싱
+- `getCurrentTeamId()`는 세션에 캐시하여 DB 조회 최소화
+- 스코프 변경 시 자동으로 캐시 무효화
+
+### 3. 권한 검증 시점
+- 스코프 설정 시: `userCanAccessScope()`로 사전 검증
+- 미들웨어: 매 요청마다 재검증 (권한 변경 반영)
+- Spatie Permission: 실제 권한 체크 시점
+
+### 4. 글로벌 컨텍스트 (team_id = null)
+- 스코프가 설정되지 않으면 `null` 반환
+- 글로벌 역할(예: `super_admin`)은 team_id=null로 부여
+
+## 테스트
+
+```php
+// 테스트에서 스코프 설정
+public function test_store_creation_in_scope()
+{
+    $user = User::factory()->create();
+    $this->actingAs($user);
+    
+    // 스코프 설정
+    scopeContext()->setScope('STORE', 123, 456);
+    
+    // 권한 체크
+    $this->assertTrue(scopeContext()->hasScope());
+    $this->assertEquals('STORE', scopeContext()->getCurrentScopeType());
+    $this->assertEquals(456, currentScopeTeamId());
+}
+```
+
+## 확장 포인트
+
+### 커스텀 스코프 타입 추가
+
+```php
+// ScopeContextService에 메서드 추가
+public function isBrandScope(): bool
+{
+    return $this->getCurrentScopeType() === 'BRAND';
+}
+```
+
+### 스코프 전환 이벤트
+
+```php
+// setScope() 메서드에 이벤트 발생 추가
+event(new ScopeChanged($scopeType, $scopeId));
+```
+
+## 관련 파일
+
+- `app/Services/ScopeContextService.php` - 핵심 서비스
+- `app/Permissions/CurrentScopeResolver.php` - Spatie 통합
+- `app/Support/helpers.php` - 헬퍼 함수
+- `app/Providers/AppServiceProvider.php` - 서비스 등록
+- `config/permission.php` - Spatie 설정


### PR DESCRIPTION
## 개요
이 PR은 RBAC Teams+Scopes 전환의 첫 번째 단계로, Spatie Permission Teams 기능을 활성화하고 세션 기반 스코프 컨텍스트 관리 시스템을 구현합니다.

## 주요 변경사항

### 1. Config 변경
- `config/permission.php`
  - `teams = true` 활성화
  - `team_resolver` 커스텀 구현으로 지정
  - 예외 메시지에 권한/역할 이름 표시 활성화 (디버깅 용이)

### 2. ScopeContextService (핵심)
- 세션 기반 스코프 컨텍스트 일원화 관리
- 주요 메서드:
  - `getCurrentScopeType/Id/TeamId()`: 현재 활성 스코프 조회
  - `setScope()`: 스코프 설정 (UI 스위처에서 호출)
  - `clearScope()`: 로그아웃/권한 상실 시 초기화
  - `userCanAccessScope()`: 사용자 권한 검증 (Membership 연동 준비)

### 3. CurrentScopeResolver
- Spatie Permission `team_resolver` 구현
- `ScopeContextService`에 위임하여 `team_id` 반환

### 4. 헬퍼 함수
- `scopeContext()`: 서비스 인스턴스 반환
- `currentScopeTeamId()`: Spatie용 team_id 반환

### 5. 서비스 등록
- `AppServiceProvider`에 `ScopeContextService` 싱글톤 등록

### 6. 문서
- `docs/scope-context-usage.md`: 사용 가이드 및 시나리오

## 설계 결정

### 세션 기반 컨텍스트 관리
- **이유**: Filament는 서버 사이드 렌더링 방식이므로 HTTP 헤더 방식은 비현실적
- **장점**: 
  - 매 요청마다 헤더 전달 불필요
  - UI 스위처에서 한 번만 설정하면 세션 유지
  - 라라벨 세션 메커니즘 활용

### 일원화된 서비스
- **이유**: 여러 곳에서 세션 키를 직접 다루면 유지보수 어려움
- **장점**:
  - 단일 진실 공급원 (Single Source of Truth)
  - 세션 키 변경 시 한 곳만 수정
  - 비즈니스 로직 캡슐화

## TODO (후속 단계에서 활성화)
- [ ] `scopes` 테이블 마이그레이션 후 `getCurrentTeamId()` DB 조회 활성화
- [ ] `Membership` 모델 구현 후 `userCanAccessScope()` 실제 검증 활성화
- [ ] `setDefaultScopeForUser()` 실제 멤버십 조회 활성화

## 테스트 계획
- [ ] 세션에 스코프 설정 후 `scopeContext()`로 조회 확인
- [ ] `CurrentScopeResolver` 호출 시 올바른 team_id 반환 확인
- [ ] 헬퍼 함수 동작 확인

## 체크리스트
- [x] Config 변경 완료
- [x] 서비스 구현 완료
- [x] 헬퍼 함수 추가
- [x] 서비스 프로바이더 등록
- [x] 문서 작성
- [ ] 리뷰 반영
- [ ] 메인 기능 브랜치로 머지

## 관련 이슈
- 메인 작업: RBAC Teams+Scopes 전환
- 다음 단계: Migrations (scopes 테이블 추가)